### PR TITLE
Initial CI setup through GitHub Actions + build fix

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -27,23 +27,23 @@ jobs:
           - os: macos-latest
             cargo-arg: amethyst_metal
 
-  steps:
-    - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: ${{ matrix.rust }}
-        override: true
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
 
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --all --examples --features ${{ matrix.cargo-arg }}
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all --examples --features ${{ matrix.cargo-arg }}
 
-    - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features ${{ matrix.cargo-arg }}
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features ${{ matrix.cargo-arg }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -36,6 +36,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.os }}
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,49 @@
+name: Rust CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+        rust:
+          - stable
+          - nightly
+          - beta
+        include:
+          - os: ubuntu-latest
+            cargo-arg: amethyst_vulkan
+
+          - os: macos-latest
+            cargo-arg: amethyst_metal
+
+  steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+        override: true
+
+    - name: Build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --all --examples --features ${{ matrix.cargo-arg }}
+
+    - name: Test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --features ${{ matrix.cargo-arg }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -28,6 +28,12 @@ jobs:
             cargo-arg: amethyst_metal
 
     steps:
+      - name: Ubuntu Required Deps
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt update
+          sudo apt install gcc pkg-config openssl libasound2-dev cmake build-essential python3 libfreetype6-dev libexpat1-dev libxcb-composite0-dev libssl-dev libx11-dev pulseaudio
+
       - uses: actions/checkout@v2
 
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,14 @@ objc = "0.2.7"
 name = "benchmark"
 harness = false
 
-[dev-dependencies.amethyst]
+# Must be kept separate and asked to the user due to missing support for conditional compilation of features
+# https://github.com/rust-lang/cargo/issues/7914
+[features]
+amethyst_metal = ["amethyst", "amethyst/metal"]
+amethyst_vulkan = ["amethyst", "amethyst/vulkan"]
+
+[dependencies.amethyst]
 version = "0.15.3"
-features = ["vulkan"]
+optional = true
+default-features = false
+features = ["renderer"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rust-AB 🚀 🤖
 **An Agent-Based Simulation engine written in Rust**
  
-[![Build Status](https://travis-ci.org/spagnuolocarmine/abm.svg?branch=master)](https://travis-ci.org/spagnuolocarmine/abm)
+![Rust CI](https://github.com/spagnuolocarmine/rust-ab/workflows/Rust%20CI/badge.svg)
 
 **Rust-AB** is a discrete events simulation engine for developing ABM simulation that is written in a novel programming language named Rust. Rust-AB is designed to be a _ready-to-use_ tool for the ABM community and for this reason the architectural concepts of the well-adopted MASON library were re-engineered to exploit the Rust peculiarities.
 

--- a/examples/antsforage_amethyst/README.md
+++ b/examples/antsforage_amethyst/README.md
@@ -7,6 +7,9 @@ An initial attempt at implementing the ants foraging simulation, with a visualiz
 Simply run `cargo run --example antsforage_amethyst --features amethyst_vulkan`, or add the `--release` flag for a slower to compile, faster to execute option.
 If you're on macOS, you have to use the metal renderer backend. To do so, swap `amethyst_vulkan` with `amethyst_metal`.
 
+# Dependencies
+If you're on linux, follow the instructions [here](https://github.com/amethyst/amethyst#dependencies)
+
 # Current issues
 - [x] Obstacles are not implemented yet; Implemented on 18/10/2020
 - [x] Pheromones lack some sort of visualization; Implemented on 18/10/2020

--- a/examples/antsforage_amethyst/README.md
+++ b/examples/antsforage_amethyst/README.md
@@ -4,7 +4,8 @@ An initial attempt at implementing the ants foraging simulation, with a visualiz
 ![](eELHp8s7FW.gif)
 
 # How to run
-Simply run `cargo run --example antsforage_amethyst`, or add the `--release` flag for a slower to compile, faster to execute option.
+Simply run `cargo run --example antsforage_amethyst --features amethyst_vulkan`, or add the `--release` flag for a slower to compile, faster to execute option.
+If you're on macOS, you have to use the metal renderer backend. To do so, swap `amethyst_vulkan` with `amethyst_metal`.
 
 # Current issues
 - [x] Obstacles are not implemented yet; Implemented on 18/10/2020

--- a/examples/boids_amethyst/README.md
+++ b/examples/boids_amethyst/README.md
@@ -5,7 +5,8 @@ Flockers was chosen since it's one of the easiest simulations.
 ![](dlnJqGql3M.gif)
 
 # How to run
-Simply run `cargo run`, or `cargo run --release` for a slower to compile, faster to execute option.
+Simply run `cargo run --example boids_amethyst --features amethyst_vulkan`, or add the  `--release` flag for a slower to compile, faster to execute option.
+If you're on macOS, you have to use the metal renderer backend. To do so, swap `amethyst_vulkan` with `amethyst_metal`.
 
 # Current issues
 - The sprite bounding box seems to not be properly aligned to the sprite itself. The collision actually

--- a/examples/boids_amethyst/README.md
+++ b/examples/boids_amethyst/README.md
@@ -8,6 +8,9 @@ Flockers was chosen since it's one of the easiest simulations.
 Simply run `cargo run --example boids_amethyst --features amethyst_vulkan`, or add the  `--release` flag for a slower to compile, faster to execute option.
 If you're on macOS, you have to use the metal renderer backend. To do so, swap `amethyst_vulkan` with `amethyst_metal`.
 
+# Dependencies
+If you're on linux, follow the instructions [here](https://github.com/amethyst/amethyst#dependencies)
+
 # Current issues
 - The sprite bounding box seems to not be properly aligned to the sprite itself. The collision actually
     happens with a smaller bounding box.


### PR DESCRIPTION
This pull requests enables a simple workflow to run cargo build & test on latest ubuntu and macos. GitHub actions are preferred over travis since the latter recently changed their billing plans for all kind of projects, requiring us to pay to do a simple CI workflow: https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
This initial CI setup takes into account the use of a different backend renderer (metal for macOS, vulkan for anything else) which was making the travis build fail on macOS.
The READMEs related to amethyst-based examples have also been updated, along with the Cargo.toml, to make Amethyst a fully optional dependency. To run examples using visualization, it is required to pass the correct feature with the run command, by choosing one of the two available features: amethyst_vulkan or amethyst_metal.
There's also a new chapter specifying the required dependencies if compiling on a linux distro.
This also avoids compiling amethyst if we do not want the visualization layer for our simulation (es. antsforage, boids, boids_ui), drastically speeding up compile times.

This pull request is to test the action itself, which runs on new commits on the master branch and on pull requests as a check.

Closes #4 

TODOS:
- [x] Cargo build and test on macOS and ubuntu
- [x] Caching of cargo artifacts
- [ ] Rustfmt
- [ ] Clippy (Will probably be done in later PRs, since there are several lint errors right now in the repository)